### PR TITLE
Reference to StringCache outliving scope

### DIFF
--- a/src/modulecache.d
+++ b/src/modulecache.d
@@ -164,13 +164,13 @@ struct ModuleCache
 			return null;
 
 		const(Token)[] tokens;
-		{
+        auto parseStringCache = StringCache(StringCache.defaultBucketCount);
+        {
 			ubyte[] source = cast(ubyte[]) Mallocator.it.allocate(fileSize);
 			scope (exit) Mallocator.it.deallocate(source);
 			f.rawRead(source);
 			LexerConfig config;
 			config.fileName = cachedLocation;
-			auto parseStringCache = StringCache(StringCache.defaultBucketCount);
 
 			// The first three bytes are sliced off here if the file starts with a
 			// Unicode byte order mark. The lexer/parser don't handle them.
@@ -178,7 +178,7 @@ struct ModuleCache
 				(source.length >= 3 && source[0 .. 3] == "\xef\xbb\xbf"c)
 				? source[3 .. $] : source,
 				config, &parseStringCache);
-		}
+        }
 
 		auto semanticAllocator = scoped!(CAllocatorImpl!(BlockAllocator!(1024 * 64)));
 		Module m = parseModuleSimple(tokens[], cachedLocation, semanticAllocator);

--- a/src/modulecache.d
+++ b/src/modulecache.d
@@ -164,8 +164,8 @@ struct ModuleCache
 			return null;
 
 		const(Token)[] tokens;
-        auto parseStringCache = StringCache(StringCache.defaultBucketCount);
-        {
+		auto parseStringCache = StringCache(StringCache.defaultBucketCount);
+		{
 			ubyte[] source = cast(ubyte[]) Mallocator.it.allocate(fileSize);
 			scope (exit) Mallocator.it.deallocate(source);
 			f.rawRead(source);
@@ -178,7 +178,7 @@ struct ModuleCache
 				(source.length >= 3 && source[0 .. 3] == "\xef\xbb\xbf"c)
 				? source[3 .. $] : source,
 				config, &parseStringCache);
-        }
+		}
 
 		auto semanticAllocator = scoped!(CAllocatorImpl!(BlockAllocator!(1024 * 64)));
 		Module m = parseModuleSimple(tokens[], cachedLocation, semanticAllocator);


### PR DESCRIPTION
19c8468 seemed to have caused a bug because tokens & parseStringCache have shared lifetimes.

Minimum reproducible example:

    import std.algorithm;
    void main(string[] args)
    {
        std.algorithm.BoyerMooreFinder(
    }

test:

     ./bin/dcd-client -c 85 main.d
no output

    ./bin/dcd-client -c 83 main.d

crash

With fix:


    ./bin/dcd-client -c 85 main.d
    calltips
    this(Range needle)


    ./bin/dcd-client -c 83 main.d
    BoyerMooreFinder	s
    boyerMooreFinder	f
