### PR TITLE
Fixup for /etc/dcd.conf support

### DIFF
--- a/src/server.d
+++ b/src/server.d
@@ -250,8 +250,8 @@ string getConfigurationLocation()
 			configDir = environment.get("HOME", null);
 			if (configDir !is null)
 				configDir = buildPath(configDir, ".config", "dcd", CONFIG_FILE_NAME);
-			else
-				configDir = "/etc/";
+			if (!exists(configDir))
+				configDir = buildPath("/etc/", CONFIG_FILE_NAME);
 		}
 		else
 		{


### PR DESCRIPTION
1) look for /etc/dcd.conf if $HOME is defined but there is no dcd.conf there
2) include missing filename in path