### PR TITLE
Fix spelling of classinfo.

### DIFF
--- a/src/actypes.d
+++ b/src/actypes.d
@@ -689,7 +689,7 @@ static this()
 	aggregateSymbols.insert(stringof_);
 	aggregateSymbols.insert(init);
 
-	classSymbols.insert(allocate!ACSymbol(Mallocator.it, internString("classInfo"), CompletionKind.variableName));
+	classSymbols.insert(allocate!ACSymbol(Mallocator.it, internString("classinfo"), CompletionKind.variableName));
 	classSymbols.insert(allocate!ACSymbol(Mallocator.it, internString("tupleof"), CompletionKind.variableName));
 	classSymbols.insert(allocate!ACSymbol(Mallocator.it, internString("__vptr"), CompletionKind.variableName));
 	classSymbols.insert(allocate!ACSymbol(Mallocator.it, internString("__monitor"), CompletionKind.variableName));


### PR DESCRIPTION
The classinfo property was mispelled as classInfo in actypes.d, resulting in
incorrect completions.
See: http://dlang.org/property.html#classinfo