### PR TITLE
Fix compiler errors on windows

### DIFF
--- a/src/client/client.d
+++ b/src/client/client.d
@@ -312,8 +312,15 @@ Socket createSocket(string socketFile, ushort port)
 	}
 	else
 	{
-		socket = new Socket(AddressFamily.UNIX, SocketType.STREAM);
-		socket.connect(new UnixAddress(socketFile));
+		version(Windows)
+		{
+			throw new Exception("Cannot use UNIX domain sockets on Windows.");
+		}
+		else
+		{
+			socket = new Socket(AddressFamily.UNIX, SocketType.STREAM);
+			socket.connect(new UnixAddress(socketFile));
+		}
 	}
 	socket.setOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, dur!"seconds"(5));
 	socket.blocking = true;

--- a/src/common/socket.d
+++ b/src/common/socket.d
@@ -42,4 +42,8 @@ string generateSocketName()
 				"dcd.socket");
 		}
 	}
+	else
+	{
+		assert(0);
+	}
 }


### PR DESCRIPTION
Checking the repo out and running dub to build on windows would
give two compiler errors, one because UnixAddress is not defined
another because a function misses a return statement if Unix sockets
are not possible.