### PR TITLE
Update build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -23,6 +23,7 @@ dmd^
  src\client\client.d^
  src\common\messages.d^
  src\common\dcd_version.d^
+ src\common\socket.d^
  msgpack-d\src\msgpack.d^
  -Imsgpack-d\src^
  -release -inline -O -wi^


### PR DESCRIPTION
The Windows build batch file must include common/socket.d in the client build following 166db74597e2bb9dc1396ed90852a06df8697fed .