### PR TITLE
Added environment variable expansion support to the server config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,11 @@ The server will attempt to read the file ```${XDG_CONFIG_HOME}/dcd/dcd.conf```
 ```dcd.conf``` on Windows in the current working directory on startup.
 If it exists, each line of the file is interpreted as a path that should be
 searched when looking for module imports. Lines that start with the "#" character
-are ignored.
+are ignored. Lines can contain environment variables which will be expanded
+during loading. The name of the environment variable needs to the enclosed in
+${VAR}. For example:
+
+	${HOME}/sysroot/usr/include/dmd/phobos
 
 Keep in mind that DCD treats import paths the same way that the compiler does.
 For example, a configuration file like this will not work as expected:


### PR DESCRIPTION
- use a replaceAll of a compile time regex to expand environment variables of
the form ${ENV_VAR} in the import paths
- added a unit test for the regex