### PR TITLE
fix #313 - ddoc, overloads sets broken

### DIFF
--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -71,48 +71,37 @@ public AutocompleteResponse getDoc(const AutocompleteRequest request,
 		warning("Could not find symbol");
 	else
 	{
-		struct Escaper(O)
+        Appender!(char[]) app;
+
+        void putDDocChar(dchar c)
+        {
+            switch (c)
+            {
+            case '\\':
+                app.put('\\');
+                app.put('\\');
+                break;
+            case '\n':
+                app.put('\\');
+                app.put('n');
+                break;
+            default:
+                app.put(c);
+                break;
+            }
+        }
+
+        void putDDocString(string s)
+        {
+            foreach (c; s)
+                putDDocChar(c);
+        }
+
+		foreach(symbol; stuff.symbols.filter!(a => !a.doc.empty))
 		{
-			this(O* or)
-			{
-				this.outputRange = or;
-			}
-
-			void put(string s)
-			{
-				foreach (c; s)
-					put(c);
-			}
-
-			void put(char c)
-			{
-				switch (c)
-				{
-				case '\\':
-					outputRange.put('\\');
-					outputRange.put('\\');
-					break;
-				case '\n':
-					outputRange.put('\\');
-					outputRange.put('n');
-					break;
-				default:
-					outputRange.put(c);
-					break;
-				}
-			}
-
-			O* outputRange;
-		}
-
-		auto app = appender!(char[])();
-		auto e = Escaper!(typeof(app))(&app);
-		foreach (symbol; stuff.symbols.filter!(a => !a.doc.empty))
-		{
-			app.clear();
-			foreach(c; symbol.doc)
-				e.put(c);
-			response.docComments ~= cast(string) app.data;
+            app.clear;
+            putDDocString(symbol.doc);
+            response.docComments ~= app.data.idup;
 		}
 	}
 	return response;

--- a/tests/tc031/expected1.txt
+++ b/tests/tc031/expected1.txt
@@ -1,0 +1,1 @@
+foo\nF\n\nbar\nB

--- a/tests/tc031/file.d
+++ b/tests/tc031/file.d
@@ -1,0 +1,12 @@
+foo;
+/**
+foo
+F
+*/
+void foo();
+
+/**
+bar
+B
+*/
+void foo(uint a); 

--- a/tests/tc031/run.sh
+++ b/tests/tc031/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -d -c1 > actual1.txt
+diff actual1.txt expected1.txt


### PR DESCRIPTION
- It was the cast to string that corrupted something. With `.idup` on the appender it works again.
- I've also took the initiative to use functions instead of the Escaper struct.
- Regression test included.

