### PR TITLE
autocomplete: Fix goto-declaration for import statements

### DIFF
--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -1153,6 +1153,7 @@ T getExpression(T)(T beforeTokens)
 		switch (beforeTokens[i].type)
 		{
 		case tok!"import":
+			i++;
 			break expressionLoop;
 		mixin (TYPE_IDENT_AND_LITERAL_CASES);
 			mixin (EXPRESSION_LOOP_BREAK);

--- a/tests/tc032/expected1.txt
+++ b/tests/tc032/expected1.txt
@@ -1,0 +1,1 @@
+/imports/std/stdio.d	0

--- a/tests/tc032/file.d
+++ b/tests/tc032/file.d
@@ -1,0 +1,1 @@
+import std.stdio;

--- a/tests/tc032/run.sh
+++ b/tests/tc032/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -l -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
+diff actual1.txt expected1.txt


### PR DESCRIPTION
https://github.com/Hackerpilot/DCD/issues/308

Seems to work and breaks no tests, but I'm not sure if this is the right way to fix it.