### PR TITLE
bump version num to v0.9.0-alpha4

### DIFF
--- a/src/common/dcd_version.d
+++ b/src/common/dcd_version.d
@@ -21,7 +21,7 @@ module common.dcd_version;
 /**
  * Human-readable version number
  */
-enum DCD_VERSION = "v0.9.0-alpha2";
+enum DCD_VERSION = "v0.9.0-alpha4";
 
 version (Windows) {}
 else version (built_with_dub) {}


### PR DESCRIPTION
I guess this should have been in alpha4 itself, but this is better than nothing?