### PR TITLE
fix #369, No completion after UDA

### DIFF
--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -1215,6 +1215,13 @@ T getExpression(T)(T beforeTokens)
 
 	expressionLoop: while (true)
 	{
+
+		if (i > 0 && beforeTokens[i].type == tok!"identifier" &&
+			beforeTokens[i-1].type == tok!"@" )
+		{
+			return beforeTokens[0 .. 0];
+		}
+
 		switch (beforeTokens[i].type)
 		{
 		case tok!"import":

--- a/tests/tc051/expected.txt
+++ b/tests/tc051/expected.txt
@@ -1,0 +1,3 @@
+identifiers
+Foo	s
+float	k

--- a/tests/tc051/file.d
+++ b/tests/tc051/file.d
@@ -1,0 +1,1 @@
+enum UDA; struct Foo{} @UDA F

--- a/tests/tc051/run.sh
+++ b/tests/tc051/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -c29 > actual.txt
+diff actual.txt expected.txt


### PR DESCRIPTION
It appears that the problem was that an identifier which is part of an UDA was seen as part of an expression. Unfortunately It seems that the fix also introduces a small regression: No call tips anymore on the UDA constructor, e.g (`struct UDA{int i;} @UDA(`). Minor issue IMO.