### PR TITLE
prevent a range error, close #368

### DIFF
--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -791,10 +791,14 @@ DSymbol*[] getSymbolsByTokenChain(T)(Scope* completionScope,
 		//writeln("<<<");
 		//dumpTokens(tokens.release);
 		//writeln("<<<");
+		if (tokens.length == 0) // workaround (#371)
+			return [];
 	}
 	else if (tokens[0] == tok!"." && tokens.length > 1)
 	{
 		tokens = tokens[1 .. $];
+		if (tokens.length == 0)	// workaround (#371)
+			return [];
 		symbols = completionScope.getSymbolsAtGlobalScope(stringToken(tokens[0]));
 	}
 	else
@@ -802,8 +806,11 @@ DSymbol*[] getSymbolsByTokenChain(T)(Scope* completionScope,
 
 	if (symbols.length == 0)
 	{
-		warning("Could not find declaration of ", stringToken(tokens[0]),
-			" from position ", cursorPosition);
+		//TODO: better bugfix for issue #368, see test case 52 or pull #371
+		if (tokens.length)
+			warning("Could not find declaration of ", stringToken(tokens[0]),
+				" from position ", cursorPosition);
+		else assert(0, "internal error");
 		return [];
 	}
 

--- a/tests/tc052/file.d
+++ b/tests/tc052/file.d
@@ -1,0 +1,1 @@
+void main(){assert(te.caretRightText == "tà");}

--- a/tests/tc052/run.sh
+++ b/tests/tc052/run.sh
@@ -1,0 +1,4 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -c46 -d


### PR DESCRIPTION
Note well that this is only a workaround and that there must be a deeper and nasty bug elsewhere. If someone has the time to cook a better fix see test case 52. For a reason the request leads to a crash if ddoc is requested for a string literal that ends with a multi byte character.