### PR TITLE
fixup #369, completion after UDA, not only calltips broken

### DIFF
--- a/tests/tc051/expected1.txt
+++ b/tests/tc051/expected1.txt
@@ -1,0 +1,2 @@
+calltips
+this(int a)

--- a/tests/tc051/file1.d
+++ b/tests/tc051/file1.d
@@ -1,0 +1,1 @@
+struct UDA{int a;} @UDA(

--- a/tests/tc051/run.sh
+++ b/tests/tc051/run.sh
@@ -3,3 +3,6 @@ set -u
 
 ../../bin/dcd-client $1 file.d -c29 > actual.txt
 diff actual.txt expected.txt
+
+../../bin/dcd-client $1 file1.d -c25 > actual1.txt
+diff actual1.txt expected1.txt


### PR DESCRIPTION
In the PR #369 I mentioned that call tip request for an UDA will be broken. Unfortunately today i've discovered that it breaks also all the other features (ddoc, goto def are useful for an UDA). This PR rewrites the fix so that it's only applied to the autocompletion.