### PR TITLE
fixup #369, dot completion broken in bodies + handle templatized UDAs

### DIFF
--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -1204,24 +1204,51 @@ bool isUdaExpression(T)(ref T tokens)
 	bool result;
 	ptrdiff_t skip;
 	ptrdiff_t i = tokens.length - 2;
-
-	while (i >= 2)
+	
+	if (i < 1)
+		return result;
+	
+	// skips the UDA ctor
+	if (tokens[i].type == tok!")")
 	{
-		if (skip == 0 && tokens[i].type == tok!"identifier" && tokens[i-1].type == tok!"@")
+		++skip;
+		--i;
+		while (i >= 2)
+		{
+			skip += tokens[i].type == tok!")";
+			skip -= tokens[i].type == tok!"(";
+			--i;
+			if (skip == 0)
+			{
+				// @UDA!(TemplateParameters)(FunctionParameters)
+				if (i > 3 && tokens[i].type == tok!"!" && tokens[i-1].type == tok!")")
+				{
+					skip = 1;
+					i -= 2;
+					continue;
+				}
+				else break;
+			}
+		}
+	}
+	
+	if (skip == 0)
+	{
+		// @UDA!SingleTemplateParameter
+		if (i > 2 && tokens[i].type == tok!"identifier" && tokens[i-1].type == tok!"!")
+		{
+			i -= 2;
+		}
+
+		// @UDA
+		if (i > 0 && tokens[i].type == tok!"identifier" && tokens[i-1].type == tok!"@")
 		{
 			result = true;
-			break;
 		}
-		
-		skip += tokens[i].type == tok!")";
-		skip -= tokens[i].type == tok!"(";
-		
-		--i;
 	}
     
 	return result;
 }
-
 
 /**
  *

--- a/tests/tc051/expected2.txt
+++ b/tests/tc051/expected2.txt
@@ -1,0 +1,9 @@
+identifiers
+alignof	k
+bar	f
+c	v
+init	k
+mangleof	k
+sizeof	k
+stringof	k
+tupleof	k

--- a/tests/tc051/file2.d
+++ b/tests/tc051/file2.d
@@ -1,0 +1,1 @@
+struct UDA(T){int a,b;} struct Foo{int c; @UDA!(int)(0,1) void bar(){this.}}

--- a/tests/tc051/run.sh
+++ b/tests/tc051/run.sh
@@ -6,3 +6,6 @@ diff actual.txt expected.txt
 
 ../../bin/dcd-client $1 file1.d -c25 > actual1.txt
 diff actual1.txt expected1.txt
+
+../../bin/dcd-client $1 file2.d -c74 > actual2.txt
+diff actual2.txt expected2.txt


### PR DESCRIPTION
Sorry, again another feature broken. Dot completion didn't work anymore if an UDA was found in the tokens and this even if the UDA was for another, very distant, declaration.