### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ What you actually want is this:
 	/usr/include/dmd/druntime/import
 	/usr/include/dmd/phobos
 
-##Shut down the server
+## Shut down the server
 The server can be shut down by running the client with the `--shutdown` option:
 
 	dcd-client --shutdown


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
